### PR TITLE
fix ModuleNotFoundError:

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setuptools.setup(
     install_requires=['fastapi','uvicorn', 'requests', 'loguru', 'fire','pyfiglet','psutil',
     'pyyaml','python-multipart','sqlalchemy'],
     version='1.0.14',
+    python_requires='>=3.10',
     long_description=long_description,
     long_description_content_type="text/markdown",
     description="WebMeter - A web api-performance tool based on jmeter.",

--- a/webmeter/__main__.py
+++ b/webmeter/__main__.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from logzero import logger
+from loguru import logger
 import platform
 import fire as fire
 


### PR DESCRIPTION
1. fix https://github.com/smart-test-ti/webmeter/issues/1
2. 对于仅允许Python 3.10及更高版本运行的包,可以在setup.py中的setup()函数中使用python_requires参数指定版本要求
>`2023-11-10 19:18:21.228 | ERROR    | __main__:checkPyVer:9 - python version must be 3.10+ ,your python version is 3.9.1
`